### PR TITLE
Exposed `protected` Transaction data

### DIFF
--- a/src/main/java/com/auth0/guardian/Guardian.java
+++ b/src/main/java/com/auth0/guardian/Guardian.java
@@ -86,9 +86,6 @@ public class Guardian {
      * transaction initiated with {@link EnrollmentType#TOTP()}) or when the user received the OTP code delivered to his
      * phone number by SMS (for a transaction initiated with {@link EnrollmentType#SMS(String)}).
      *
-     * This method can be used in stateful applications where a {@link Transaction} is preserved in memory between user
-     * interactions.
-     *
      * @param transaction the enrollment transaction
      * @param otp         the code obtained from the TOTP app or delivered to the phone number by SMS
      * @return extra information about the enrollment, like the recovery code
@@ -119,8 +116,8 @@ public class Guardian {
      * transaction initiated with {@link EnrollmentType#TOTP()}) or when the user received the OTP code delivered to his
      * phone number by SMS (for a transaction initiated with {@link EnrollmentType#SMS(String)}).
      *
-     * This method can be used in stateless applications where {@link Transaction} may not be preserved between user
-     * interactions.
+     * This overload is intended for stateless applications where {@link java.io.Serializable} is not acceptable,
+     * avoiding the necessity of utilising poor practises to preserve {@link Transaction} between user actions.
      *
      * @param transactionToken the token associated with the transaction to confirm.
      * @param otp              the code obtained from the TOTP app or delivered to the phone number by SMS
@@ -128,7 +125,7 @@ public class Guardian {
      * @throws IllegalArgumentException when the transaction is not valid
      * @throws GuardianException        when there's a Guardian specific issue (invalid otp for example)
      */
-    public void confirmEnrollStateless(String transactionToken, String otp)
+    public void confirmEnroll(String transactionToken, String otp)
             throws IOException, IllegalArgumentException, GuardianException {
         if (transactionToken == null) {
             throw new IllegalArgumentException("Invalid enrollment transaction");

--- a/src/main/java/com/auth0/guardian/Guardian.java
+++ b/src/main/java/com/auth0/guardian/Guardian.java
@@ -86,6 +86,9 @@ public class Guardian {
      * transaction initiated with {@link EnrollmentType#TOTP()}) or when the user received the OTP code delivered to his
      * phone number by SMS (for a transaction initiated with {@link EnrollmentType#SMS(String)}).
      *
+     * This method can be used in stateful applications where a {@link Transaction} is preserved in memory between user
+     * interactions.
+     *
      * @param transaction the enrollment transaction
      * @param otp         the code obtained from the TOTP app or delivered to the phone number by SMS
      * @return extra information about the enrollment, like the recovery code
@@ -107,5 +110,35 @@ public class Guardian {
                 .execute();
 
         return new Enrollment(transaction.getRecoveryCode());
+    }
+
+    /**
+     * Confirms an enrollment started with {@link Guardian#requestEnroll(String, EnrollmentType)}.
+     * <p>
+     * Use this method to confirm an enrollment transaction once the user scanned the QR code with a TOTP app (for a
+     * transaction initiated with {@link EnrollmentType#TOTP()}) or when the user received the OTP code delivered to his
+     * phone number by SMS (for a transaction initiated with {@link EnrollmentType#SMS(String)}).
+     *
+     * This method can be used in stateless applications where {@link Transaction} may not be preserved between user
+     * interactions.
+     *
+     * @param transactionToken the token associated with the transaction to confirm.
+     * @param otp              the code obtained from the TOTP app or delivered to the phone number by SMS
+     * @throws IOException              when there's a connection issue
+     * @throws IllegalArgumentException when the transaction is not valid
+     * @throws GuardianException        when there's a Guardian specific issue (invalid otp for example)
+     */
+    public void confirmEnrollStateless(String transactionToken, String otp)
+            throws IOException, IllegalArgumentException, GuardianException {
+        if (transactionToken == null) {
+            throw new IllegalArgumentException("Invalid enrollment transaction");
+        }
+        if (otp == null) {
+            throw new IllegalArgumentException("Invalid OTP");
+        }
+
+        apiClient
+                .verifyOTP(transactionToken, otp)
+                .execute();
     }
 }

--- a/src/main/java/com/auth0/guardian/Transaction.java
+++ b/src/main/java/com/auth0/guardian/Transaction.java
@@ -48,11 +48,11 @@ public class Transaction implements Serializable {
         this.otpSecret = otpSecret;
     }
 
-    String getTransactionToken() {
+    public String getTransactionToken() {
         return transactionToken;
     }
 
-    String getRecoveryCode() {
+    public String getRecoveryCode() {
         return recoveryCode;
     }
 

--- a/src/test/java/com/auth0/guardian/GuardianTest.java
+++ b/src/test/java/com/auth0/guardian/GuardianTest.java
@@ -240,7 +240,7 @@ public class GuardianTest {
         server.emptyResponse();
 
         guardian
-                .confirmEnroll(null, OTP_CODE);
+                .confirmEnroll((Transaction)null, OTP_CODE);
     }
 
     @Test


### PR DESCRIPTION
This library is largely unopinionated, to the point that it does not even expose its own HTTP client's async types. The dependency on Java's `Serializable` contradicts this sentiment, and I'm keen to see it removed.

The aim of this PR is to make available to developers the information associated with a `Transaction` to avoid the necessity of serializing it through a poor mechanism. Correspondingly, `Guardian#confirmEnroll(String, String)` has been added as an overload on `Guardian#confirmEnroll(Transaction, String)` to represent more accurately what information is necessary for the method to succeed.