### PR TITLE
Map transaction_not_found error and expose APIClient

### DIFF
--- a/src/main/java/com/auth0/guardian/APIClient.java
+++ b/src/main/java/com/auth0/guardian/APIClient.java
@@ -28,16 +28,16 @@ import okhttp3.HttpUrl;
 import okhttp3.OkHttpClient;
 import okhttp3.logging.HttpLoggingInterceptor;
 
-class APIClient {
+public class APIClient {
 
     private final HttpUrl baseUrl;
     private final RequestFactory requestFactory;
 
-    APIClient(HttpUrl baseUrl) {
+    public APIClient(HttpUrl baseUrl) {
         this(baseUrl, new OkHttpClient.Builder().addInterceptor(new HttpLoggingInterceptor().setLevel(HttpLoggingInterceptor.Level.BODY)).build());
     }
 
-    APIClient(HttpUrl baseUrl, OkHttpClient client) {
+    public APIClient(HttpUrl baseUrl, OkHttpClient client) {
         this(baseUrl, new RequestFactory(client));
     }
 

--- a/src/main/java/com/auth0/guardian/Guardian.java
+++ b/src/main/java/com/auth0/guardian/Guardian.java
@@ -35,13 +35,22 @@ public class Guardian {
      *
      * @param baseUrl the Guardian server URL
      */
-    public Guardian(String baseUrl) {
+    public static Guardian fromBaseUrl(String baseUrl) {
         HttpUrl url = HttpUrl.parse(baseUrl);
         if (url == null) {
             throw new IllegalArgumentException("Invalid base URL: " + baseUrl);
         }
 
-        this.apiClient = new APIClient(url);
+        return new Guardian(new APIClient(url));
+    }
+
+    /**
+     * Creates an instance for a specific Guardian API client
+     *
+     * @param apiClient the Guardian API client
+     */
+    public Guardian(APIClient apiClient) {
+        this.apiClient = apiClient;
     }
 
     /**

--- a/src/main/java/com/auth0/guardian/GuardianException.java
+++ b/src/main/java/com/auth0/guardian/GuardianException.java
@@ -35,8 +35,8 @@ public class GuardianException extends RuntimeException {
     private static final String ERROR_DEVICE_ACCOUNT_NOT_FOUND = "device_account_not_found";
     private static final String ERROR_ENROLLMENT_NOT_FOUND = "enrollment_not_found";
     private static final String ERROR_LOGIN_TRANSACTION_NOT_FOUND = "login_transaction_not_found";
-
     private static final String ERROR_ALREADY_ENROLLED = "already_enrolled";
+    private static final String ERROR_TRANSACTION_NOT_FOUND = "transaction_not_found";
 
     private final Map<String, Object> errorResponse;
     private final String errorCode;
@@ -113,6 +113,15 @@ public class GuardianException extends RuntimeException {
      */
     public boolean isAlreadyEnrolled() {
         return ERROR_ALREADY_ENROLLED.equals(errorCode);
+    }
+
+    /**
+     * Whether the error is caused by a transaction not found (e.g. already confirmed)
+     *
+     * @return true if error is caused by the transaction not found
+     */
+    public boolean isTransactionNotFound() {
+        return ERROR_TRANSACTION_NOT_FOUND.equals(errorCode);
     }
 
     @Override

--- a/src/test/java/com/auth0/guardian/GuardianTest.java
+++ b/src/test/java/com/auth0/guardian/GuardianTest.java
@@ -56,7 +56,7 @@ public class GuardianTest {
     @Before
     public void setUp() throws Exception {
         server = new MockServer();
-        guardian = new Guardian(server.getBaseUrl().toString());
+        guardian = Guardian.fromBaseUrl(server.getBaseUrl().toString());
     }
 
     @After
@@ -68,7 +68,7 @@ public class GuardianTest {
     public void shouldFailWithNullUrl() throws Exception {
         exception.expect(NullPointerException.class);
 
-        new Guardian(null);
+        Guardian.fromBaseUrl(null);
     }
 
     @Test
@@ -76,7 +76,7 @@ public class GuardianTest {
         exception.expect(IllegalArgumentException.class);
         exception.expectMessage("Invalid base URL: some invalid URL");
 
-        new Guardian("some invalid URL");
+        Guardian.fromBaseUrl("some invalid URL");
     }
 
     @Test

--- a/src/test/java/com/auth0/guardian/TestApp.java
+++ b/src/test/java/com/auth0/guardian/TestApp.java
@@ -28,7 +28,7 @@ public class TestApp {
 
     public static void main(String[] args) {
 
-        Guardian guardian = new Guardian("https://<tenant>.guardian.auth0.com");
+        Guardian guardian = Guardian.fromBaseUrl("https://<tenant>.guardian.auth0.com");
 
         // obtain an enrollment ticket for the user
         String enrollmentTicket = "Ag1qX7vZVBvyTKhFwrkzaCH2M8vn5b6c";


### PR DESCRIPTION
Confirming with an already confirmed transaction token responds with `transaction_not_found`. We would also like to get access to the underlying OkHttp client. If that is undesirable, we would at least like to either remove or allow a configuration to disable the configured HttpLoggingInterceptor since it poses a security risk. 