### PR TITLE
Exposed OTP secret for not-yet serialised Transaction entities

### DIFF
--- a/src/test/java/com/auth0/guardian/GuardianTest.java
+++ b/src/test/java/com/auth0/guardian/GuardianTest.java
@@ -98,6 +98,7 @@ public class GuardianTest {
         assertThat(transaction, is(notNullValue()));
         assertThat(transaction.getTransactionToken(), is(equalTo("THE_TRANSACTION_TOKEN")));
         assertThat(transaction.getRecoveryCode(), is(equalTo("THE_RECOVERY_CODE")));
+        assertThat(transaction.getTotpSecret(), is(equalTo("THE_OTP_SECRET")));
         assertThat(transaction.totpURI("user", "issuer"), is(equalTo("otpauth://totp/issuer:user?secret=THE_OTP_SECRET&issuer=issuer")));
     }
 
@@ -130,6 +131,7 @@ public class GuardianTest {
         assertThat(transaction, is(notNullValue()));
         assertThat(transaction.getTransactionToken(), is(equalTo("THE_TRANSACTION_TOKEN")));
         assertThat(transaction.getRecoveryCode(), is(equalTo("THE_RECOVERY_CODE")));
+        assertThat(transaction.getTotpSecret(), is(equalTo("THE_OTP_SECRET")));
         assertThat(transaction.totpURI("user", "issuer"), is(equalTo("otpauth://totp/issuer:user?secret=THE_OTP_SECRET&issuer=issuer")));
     }
 

--- a/src/test/java/com/auth0/guardian/TransactionTest.java
+++ b/src/test/java/com/auth0/guardian/TransactionTest.java
@@ -46,6 +46,7 @@ public class TransactionTest {
 
         assertThat(transaction.getTransactionToken(), is(equalTo("TRANSACTION_TOKEN")));
         assertThat(transaction.getRecoveryCode(), is(equalTo("RECOVERY_CODE")));
+        assertThat(transaction.getTotpSecret(), is(equalTo("OTP_SECRET")));
         assertThat(transaction.totpURI("username", "company"), is(equalTo("otpauth://totp/company:username?secret=OTP_SECRET&issuer=company")));
     }
 
@@ -55,6 +56,7 @@ public class TransactionTest {
 
         assertThat(transaction.getTransactionToken(), is(equalTo("TRANSACTION_TOKEN")));
         assertThat(transaction.getRecoveryCode(), is(equalTo("RECOVERY_CODE")));
+        assertThat(transaction.getTotpSecret(), is(equalTo("OTP_SECRET")));
         assertThat(transaction.totpURI("user name", "company name"), is(equalTo("otpauth://totp/company%20name:user%20name?secret=OTP_SECRET&issuer=company%20name")));
     }
 
@@ -64,6 +66,7 @@ public class TransactionTest {
 
         assertThat(transaction.getTransactionToken(), is(equalTo("TRANSACTION_TOKEN")));
         assertThat(transaction.getRecoveryCode(), is(equalTo("RECOVERY_CODE")));
+        assertThat(transaction.getTotpSecret(), is(equalTo("OTP_SECRET")));
         assertThat(transaction.totpURI("user%name", "compañy?!"), is(equalTo("otpauth://totp/compa%C3%B1y%3F!:user%25name?secret=OTP_SECRET&issuer=compa%C3%B1y?!")));
     }
 
@@ -89,6 +92,32 @@ public class TransactionTest {
 
         assertThat(restoredTransaction.getTransactionToken(), is(equalTo("TRANSACTION_TOKEN")));
         assertThat(restoredTransaction.getRecoveryCode(), is(equalTo("RECOVERY_CODE")));
+    }
+
+    @Test
+    public void shouldThrowWhenRequestingOtpSecretAfterSerialization() throws Exception {
+        exception.expect(IllegalStateException.class);
+        exception.expectMessage("There is no OTP Secret for this transaction");
+
+        Transaction transaction = new Transaction("TRANSACTION_TOKEN", "RECOVERY_CODE", "OTP_SECRET");
+
+        // save
+        ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+        ObjectOutputStream objectOutputStream = new ObjectOutputStream(outputStream);
+        objectOutputStream.writeObject(transaction);
+        objectOutputStream.close();
+        outputStream.close();
+
+        byte[] binaryData = outputStream.toByteArray();
+
+        // restore
+        ByteArrayInputStream inputStream = new ByteArrayInputStream(binaryData);
+        ObjectInputStream objectInputStream = new ObjectInputStream(inputStream);
+        Transaction restoredTransaction = (Transaction) objectInputStream.readObject();
+        objectInputStream.close();
+        inputStream.close();
+
+        restoredTransaction.getTotpSecret();
     }
 
     @Test


### PR DESCRIPTION
The raw OTP secret is required for enrollments on devices without cameras, as well as on devices that have damaged/broken cameras. Authy, Google Authenticator and Microsoft Authenticator all permit manual entry of the Base32-encoded secret, and we'd like to support that for our users.

While the TOTP URI's structure is dictated by a standard, it feels pretty dirty to decode a string that was encoded milliseconds previously, and there is no security benefit to concealing the raw secret.